### PR TITLE
Update ESP8266_H801.ino

### DIFF
--- a/ESP8266/ESP8266_H801/ESP8266_H801.ino
+++ b/ESP8266/ESP8266_H801/ESP8266_H801.ino
@@ -111,6 +111,7 @@ void setup()
   Serial1.begin(115200);
 #endif
 
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
   wifiConnect();
 


### PR DESCRIPTION
I noticed that the ESP is still broadcasting its own "wifi network" by default. It shows up in my available wifi networks as ESP_xxxxxx where xxxxxx is the ID number of my ESP. Even if it is alreay connected to my wifi network and also shows up in my router and has its own IP adress. I can also connect to this unsecured ESP_xxxxxx "wifi network".

I found the solution for the ESP broadcasting it's own network.

Just symply add this line in the code for the H801:
WiFi.mode(WIFI_STA);
I placed this line just above the already existing line:
WiFi.begin(ssid, password);

This sets the wifi mode of the ESP to "workstation" instead of the default "workstation + acces point".
(The 3 available modes are: WIFI_AP, WIFI_STA, or WIFI_AP_STA, see this discussion).